### PR TITLE
カレンダーの月を返すAPIエンドポイント作成

### DIFF
--- a/laravel/app/Http/Controllers/CalenderController.php
+++ b/laravel/app/Http/Controllers/CalenderController.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Http\Controllers;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Http\JsonResponse;
+use App\Services\CalenderService;
+class CalenderController extends BaseController
+{
+    protected $calendar;
+    public function __construct(
+        CalenderService $calendar,
+        )
+    {
+        $this->calendar = $calendar;
+    }
+    public function put($month): JsonResponse
+    {
+        $nihonCalendar =$this->calendar->getNihonCalendarData($month);
+        $englishCalendar = $this->getEnglishCalendarData($month);
+        return response()->json([
+            'calender' => [
+                'nihon' => $nihonCalendar,
+                'english' => $englishCalendar
+            ]
+        ]);
+    }
+    public function getEnglishCalendarData(int $month): string
+    {
+        $englishCalendarData = [
+            1 => 'January',
+            2 => 'February',
+            3 => 'March',
+            4 => 'April',
+            5 => 'May',
+            6 => 'June',
+            7 => 'July',
+            8 => 'August',
+            9 => 'September',
+            10 => 'October',
+            11 => 'November',
+            12 => 'December'
+        ];
+        return $englishCalendarData[$month];
+    }
+}

--- a/laravel/app/Repositories/CalenderRepository.php
+++ b/laravel/app/Repositories/CalenderRepository.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\Repositories;
+/**
+ * Class CalenderRepository
+ * @package App\Repositories
+ */
+class CalenderRepository {
+    // 仮定としてDB層にアクセスするためのリポジトリ層。DBに接続したものと仮定し、idカラムとmonthカラムがあるテーブルにデータ取得するとする。
+    public function getNihonCalendarData($month)
+    {
+        $nihonCalendarData = [
+            // キー：idカラム、バリュー：monthカラム
+            1 => '1月',
+            2 => '2月',
+            3 => '3月',
+            4 => '4月',
+            5 => '5月',
+            6 => '6月',
+            7 => '7月',
+            8 => '8月',
+            9 => '9月',
+            10 => '10月',
+            11 => '11月',
+            12 => '12月'
+        ];
+        return $nihonCalendarData[$month];
+    }
+}

--- a/laravel/app/Services/CalenderService.php
+++ b/laravel/app/Services/CalenderService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services;
+
+use Exception;
+use App\Repositories\CalenderRepository;
+
+/**
+ * Class SampleService
+ * @package App\Services
+ */
+class CalenderService
+{
+    protected $calenderRepository;
+
+    public function __construct(
+        CalenderRepository $calenderRepository,
+        ) 
+    {
+        $this->calenderRepository = $calenderRepository;
+    }
+
+    public function getNihonCalendarData($month)
+    {
+        $nihonCalendarData = $this->calenderRepository->getNihonCalendarData($month);
+        return $nihonCalendarData;
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\CalenderController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/calender/put/{month}', [CalenderController::class, 'put']);


### PR DESCRIPTION
## 概要
http://127.0.0.1:8080/calender/put/{month}
上記パスパラメータに1など月の値を入れると、日本語の1月や英語のJanuaryを返すAPIエンドポイントを作成した。

- Controller
Serviceから受けとったデータをJSONに返す役割
- Service
業務ロジックの役割
- Repository
DBへのデータアクセスの役割（今回は仮で配列として用意している）

## 参考画像
![image](https://github.com/user-attachments/assets/1c54ef94-d603-4a99-8fe5-a741ecf9cdea)



## API仕様書
API仕様書をベースとして実装に書き起こす。
API仕様書に対しても気になる点があれば適宜コメントしてもらう。
![image](https://github.com/user-attachments/assets/79acec76-5cb9-4a93-becb-090da76745e4)

